### PR TITLE
Silken Tofu now yields a bowl [refs #9]

### DIFF
--- a/src/main/java/de/chrisimo/vegandelight/item/ModItems.java
+++ b/src/main/java/de/chrisimo/vegandelight/item/ModItems.java
@@ -26,11 +26,11 @@ public class ModItems {
                     .saturationMod(0.4f)
                     .build())));
     public static final RegistryObject<Item> SILKEN_TOFU = ITEMS.register("silken_tofu",
-            () -> new Item(new Item.Properties().food(new FoodProperties.Builder()
+            () -> new ConsumableItem(new Item.Properties().food(new FoodProperties.Builder()
                     .nutrition(4)
                     .saturationMod(0.4f)
                     .build())
-                    .craftRemainder(Items.BUCKET)
+                    .craftRemainder(Items.BOWL)
                     .stacksTo(16)));
     public static final RegistryObject<Item> SMOKED_TOFU = ITEMS.register("smoked_tofu",
             () -> new Item(new Item.Properties().food(new FoodProperties.Builder()


### PR DESCRIPTION
Small PR to change silken tofu to yield a bowl when consumed by making silken tofu a FD `ConsumableItem`.  (Previously it was set to bucket, and `craftRemainder()` doesn't work with food by default, I guess?)