### PR TITLE
Flip around how we tell FD about the VD Soybean Bag [refs #18]

### DIFF
--- a/src/main/resources/data/farmersdelight/tags/blocks/straw_blocks.json
+++ b/src/main/resources/data/farmersdelight/tags/blocks/straw_blocks.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "vegandelight:soybean_bag"
+  ]
+}

--- a/src/main/resources/data/vegandelight/tags/blocks/straw_blocks.json
+++ b/src/main/resources/data/vegandelight/tags/blocks/straw_blocks.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "farmersdelight:soybean_bag"
-  ]
-}


### PR DESCRIPTION
Per #18, we were trying to tag the VD Soybean Bag with FD's **straw_blocks**, but instead we were tagging the FD Soybean Bag with a VD tag, oops.  This PR swaps things around, which gets rid of the error in the log and makes the VD Soybean Bag knife-mineable like other straw blocks.

Here it is next to a FD Rice Bag:

![breaking_bag](https://github.com/SayWhatSayMon/VeganDelight/assets/2699775/9c9ccdb7-f14a-4e9c-be37-996a9e521647)
