### PR TITLE
Only load fluids when Create Central Kitchen is present [refs #25]

### DIFF
--- a/src/main/java/de/chrisimo/vegandelight/VeganDelight.java
+++ b/src/main/java/de/chrisimo/vegandelight/VeganDelight.java
@@ -34,7 +34,7 @@ public class VeganDelight
         ModItems.register(modEventBus);
         ModBlocks.register(modEventBus);
 
-        if (loadFluids()) {
+        if (shouldLoadFluids()) {
             ModFluidTypes.register(modEventBus);
             ModFluids.register(modEventBus);
         }
@@ -43,7 +43,7 @@ public class VeganDelight
         modEventBus.addListener(this::commonSetup);
     }
 
-    private boolean loadFluids()
+    private boolean shouldLoadFluids()
     {
         return ModList.get().isLoaded("create_central_kitchen");
     }

--- a/src/main/java/de/chrisimo/vegandelight/VeganDelight.java
+++ b/src/main/java/de/chrisimo/vegandelight/VeganDelight.java
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.FlowerPotBlock;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -32,11 +33,19 @@ public class VeganDelight
         ModCreativeTabs.register(modEventBus);
         ModItems.register(modEventBus);
         ModBlocks.register(modEventBus);
-        ModFluidTypes.register(modEventBus);
-        ModFluids.register(modEventBus);
+
+        if (loadFluids()) {
+            ModFluidTypes.register(modEventBus);
+            ModFluids.register(modEventBus);
+        }
 
         // Register the commonSetup method for modloading
         modEventBus.addListener(this::commonSetup);
+    }
+
+    private boolean loadFluids()
+    {
+        return ModList.get().isLoaded("create_central_kitchen");
     }
 
     private void commonSetup(final FMLCommonSetupEvent event)


### PR DESCRIPTION
Added a check for whether to load fluids in the initialization code.  Today it just depends on whether Create Central Kitchen is loaded.

Seems to remove them from JEI, however:

![image](https://github.com/SayWhatSayMon/VeganDelight/assets/2699775/391f0a1f-20f4-4011-b34d-708074eafbb5)

Let me know if you have a better idea!