### PR TITLE
Make leather substitute actually replace leather in recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 minecraft {
+
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+
     // The mappings can be changed at any time and must be in the following format.
     // Channel:   Version:
     // official   MCVersion             Official field/method names from Mojang mapping files

--- a/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
+++ b/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
@@ -1,0 +1,67 @@
+package de.chrisimo.vegandelight;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeManager;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RecipeManipulation {
+
+    private static final Logger logger = LoggerFactory.getLogger("Vegan Delight/recipe modifiers");
+    private static final Map<Item, Ingredient.Value> registeredSubstitutes = new HashMap<>();
+
+    static void load(@NotNull RecipeManager recipeManager) {
+        var allRecipes = recipeManager.getRecipes();
+
+        logger.info("Scanning {} recipes for modification", allRecipes.size());
+        AtomicInteger ingredientsChanged = new AtomicInteger();
+
+        for (Recipe<?> recipe : allRecipes) {
+            NonNullList<Ingredient> ingredients = recipe.getIngredients();
+
+            for (Ingredient ingredient : ingredients) {
+                registeredSubstitutes.forEach((item, substitute) -> {
+                    for (ItemStack stack : ingredient.getItems()) {
+                        if (stack.is(item)) {
+                            addSubstitute(ingredient, substitute);
+                            ingredientsChanged.getAndIncrement();
+                        }
+                    }
+                });
+            }
+        }
+
+        logger.info("Modified {} recipe ingredients", ingredientsChanged);
+    }
+
+    private static void addSubstitute(@NotNull Ingredient ingredient, Ingredient.Value substitute) {
+        ingredient.values = Arrays.copyOf(ingredient.values, ingredient.values.length + 1);
+        ingredient.values[ingredient.values.length - 1] = substitute;
+
+        ingredient.stackingIds = null;
+        ingredient.itemStacks = null;
+    }
+
+    public static void registerSubstitute(Item item, Ingredient.Value substitute) {
+        registeredSubstitutes.put(item, substitute);
+    }
+
+    public static void registerSubstitute(Item item, Item substitute) {
+        registerSubstitute(item, new Ingredient.ItemValue(new ItemStack(substitute)));
+    }
+
+    public static void registerSubstitute(Item item, TagKey<Item> substitute) {
+        registerSubstitute(item, new Ingredient.TagValue(substitute));
+    }
+}

--- a/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
+++ b/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
@@ -1,7 +1,6 @@
 package de.chrisimo.vegandelight;
 
 import net.minecraft.core.NonNullList;
-import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -61,7 +60,4 @@ public class RecipeManipulation {
         registerSubstitute(item, new Ingredient.ItemValue(new ItemStack(substitute)));
     }
 
-    public static void registerSubstitute(Item item, TagKey<Item> substitute) {
-        registerSubstitute(item, new Ingredient.TagValue(substitute));
-    }
 }

--- a/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
+++ b/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
@@ -41,7 +41,7 @@ public class RecipeManipulation {
     }
 
     /**
-     * checks if a substitute should be registered for an ingredient.
+     * checks if a substitute should be registered for an ingredient and applies the modification if so.
      * returns true if the ingredient was changed
      */
     private static boolean modifyIngredient(@NotNull Ingredient ingredient, Item item, Ingredient.Value substitute) {

--- a/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
+++ b/src/main/java/de/chrisimo/vegandelight/RecipeManipulation.java
@@ -32,7 +32,7 @@ public class RecipeManipulation {
             for (Ingredient ingredient : ingredients) {
                 registeredSubstitutes.forEach((item, substitute) -> {
                     for (ItemStack stack : ingredient.getItems()) {
-                        if (stack.is(item)) {
+                        if (stack.is(item) && !substitute.getItems().contains(item.getDefaultInstance())) {
                             addSubstitute(ingredient, substitute);
                             ingredientsChanged.getAndIncrement();
                         }

--- a/src/main/java/de/chrisimo/vegandelight/VeganDelight.java
+++ b/src/main/java/de/chrisimo/vegandelight/VeganDelight.java
@@ -1,6 +1,5 @@
 package de.chrisimo.vegandelight;
 
-import com.mojang.logging.LogUtils;
 import de.chrisimo.vegandelight.block.ModBlocks;
 import de.chrisimo.vegandelight.fluid.ModFluidTypes;
 import de.chrisimo.vegandelight.fluid.ModFluids;
@@ -14,16 +13,15 @@ import net.minecraft.world.item.trading.MerchantOffer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraft.world.level.block.FlowerPotBlock;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.village.VillagerTradesEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.slf4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -85,6 +83,12 @@ public class VeganDelight
                         0.05f // Price multiplier
                 ));
             }
+        }
+
+        @SubscribeEvent
+        public static void onRecipesLoaded(@NotNull ServerStartingEvent event) {
+            RecipeManipulation.registerSubstitute(Items.LEATHER, ModItems.LEATHER_SUBSTITUTE.get());
+            RecipeManipulation.load(event.getServer().getRecipeManager());
         }
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,3 @@
+public-f net.minecraft.world.item.crafting.Ingredient f_43902_ # values
+public net.minecraft.world.item.crafting.Ingredient f_43904_ # stackingIds
+public net.minecraft.world.item.crafting.Ingredient f_43903_ # itemStacks


### PR DESCRIPTION
This PR adds the `RecipeManipulation` class which allows modifying recipes at runtime (using some access transformers that were added to allow changing normally private fields) and therefore allow replacing leather with leather substitute in all recipes.

Marked as a draft, because it's not tested super well yet, and I'm not sure about the forge-specific things - is the `NewSubscriber` class the right place to put the listener or is there a different preferred way?