### PR TITLE
Compatibility with Jars from Supplementaries

### DIFF
--- a/src/main/resources/data/vegandelight/moonlight/soft_fluids/applesauce_fluid.json
+++ b/src/main/resources/data/vegandelight/moonlight/soft_fluids/applesauce_fluid.json
@@ -7,7 +7,7 @@
         "vegandelight:applesauce"
       ],
       "empty": "minecraft:bowl",
-      "capacity": "BOWL"
+      "capacity": 1
     },
     {
       "filled": [

--- a/src/main/resources/data/vegandelight/moonlight/soft_fluids/applesauce_fluid.json
+++ b/src/main/resources/data/vegandelight/moonlight/soft_fluids/applesauce_fluid.json
@@ -1,0 +1,33 @@
+{
+  "id":"vegandelight:applesauce_fluid",
+  "color": "#f0ebc0",
+  "containers": [
+    {
+      "filled": [
+        "vegandelight:applesauce"
+      ],
+      "empty": "minecraft:bowl",
+      "capacity": "BOWL"
+    },
+    {
+      "filled": [
+        "vegandelight:applesauce_bucket"
+      ],
+      "fill_sound": "minecraft:item.bucket.fill",
+      "empty_sound": "minecraft:item.bucket.empty",
+      "empty": "minecraft:bucket",
+      "capacity": "BUCKET"
+    }
+  ],
+  "equivalent_fluids": [
+    "vegandelight:applesauce_fluid"
+  ],
+  "flowing_texture": "vegandelight:block/fluid/gloppy_still",
+  "food": {
+    "divider": "BUCKET",
+    "item": "vegandelight:applesauce_bucket"
+  },
+  "still_texture": "vegandelight:block/fluid/gloppy_still",
+  "translation_key": "fluid_type.vegandelight.applesauce",
+  "use_texture_from": "vegandelight:applesauce_fluid"
+}

--- a/src/main/resources/data/vegandelight/moonlight/soft_fluids/soymilk.json
+++ b/src/main/resources/data/vegandelight/moonlight/soft_fluids/soymilk.json
@@ -1,0 +1,32 @@
+{
+  "containers": [
+    {
+      "filled": [
+        "vegandelight:soymilk_bottle"
+      ],
+      "empty": "minecraft:glass_bottle",
+      "capacity": "BOTTLE"
+    },
+    {
+      "filled": [
+        "vegandelight:soymilk_bucket"
+      ],
+      "fill_sound": "minecraft:item.bucket.fill",
+      "empty_sound": "minecraft:item.bucket.empty",
+      "empty": "minecraft:bucket",
+      "capacity": "BUCKET"
+    }
+  ],
+  "equivalent_fluids": [
+    "vegandelight:soymilk_fluid"
+  ],
+  "flowing_texture": "vegandelight:block/fluid/milky_still",
+  "food": {
+    "divider": "BUCKET",
+    "item": "vegandelight:soymilk_bucket"
+  },
+  "still_texture": "vegandelight:block/fluid/milky_still",
+  "tint_method": "no_tint",
+  "translation_key": "fluid_type.vegandelight.soymilk",
+  "use_texture_from": "vegandelight:soymilk_fluid"
+}


### PR DESCRIPTION
This would add compatibility with the soft fluid system from Moonlight that is used for both the jars from Supplementaries and the improved Cauldrons from Amendments.

Added for Soymilk, which had zero compatibility before, and improved for Applesauce, which can now be inserted or extracted with a bowl.