### PR TITLE
[1.21.1] Add config for disabling labeling

### DIFF
--- a/common/src/main/java/net/player005/vegandelightfabric/VeganConfig.java
+++ b/common/src/main/java/net/player005/vegandelightfabric/VeganConfig.java
@@ -6,29 +6,10 @@ import eu.midnightdust.lib.config.MidnightConfig;
 public class VeganConfig extends MidnightConfig {
     public static final String LABELS = "labels";
 
+    @Entry(category = LABELS) public static DataComponentUsageMode useComponents = DataComponentUsageMode.ALL_ITEMS;
     @Comment(category = LABELS) public static Comment dataComponentExplanation;
-    @Comment(category = LABELS) public static Comment spacer1;
-    @Comment(category = LABELS) public static Comment spacer2;
-
-    @Entry(category = LABELS) public static DataComponentUsageMode useComponents = DataComponentUsageMode.ONLY_FOODS;
-
-    @Comment(category = LABELS) public static Comment spacer3;
-    @Comment(category = LABELS) public static Comment labelExplanation;
-    @Comment(category = LABELS) public static Comment spacer4;
-
-    @Entry(category = LABELS) public static VeganLabelMode veganLabelMode = VeganLabelMode.ONLY_WHEN_REPLACEMENT_USED;
-
-    @Entry(category = LABELS) public static NotVeganLabelMode notVeganLabelMode = NotVeganLabelMode.ONLY_EXCEPTIONS;
 
     public enum DataComponentUsageMode {
-        ALL_ITEMS, ONLY_FOODS, NONE
-    }
-
-    public enum VeganLabelMode {
-        ALL_VEGAN_ITEMS, ONLY_WHEN_REPLACEMENT_USED, NONE
-    }
-
-    public enum NotVeganLabelMode {
-        ALL_NON_VEGAN_ITEMS, ALL_NON_VEGAN_FOODS, ONLY_EXCEPTIONS, NONE
+        ALL_ITEMS, NONE
     }
 }

--- a/common/src/main/java/net/player005/vegandelightfabric/labels/VeganLabels.java
+++ b/common/src/main/java/net/player005/vegandelightfabric/labels/VeganLabels.java
@@ -13,6 +13,7 @@ import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeInput;
 import net.player005.recipe_modification.api.RecipeModification;
+import net.player005.vegandelightfabric.VeganConfig;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,10 @@ public class VeganLabels {
 
     @ApiStatus.Internal
     public static void initialize() {
+        if (VeganConfig.useComponents == VeganConfig.DataComponentUsageMode.NONE) {
+            return;
+        }
+
         RecipeModification.registerGlobalResultModifier((recipe, result, recipeInput) -> {
             if (recipeInput != null) modifyRecipeResult(recipeInput, result);
             return result;

--- a/common/src/main/java/net/player005/vegandelightfabric/labels/VeganLabels.java
+++ b/common/src/main/java/net/player005/vegandelightfabric/labels/VeganLabels.java
@@ -60,6 +60,10 @@ public class VeganLabels {
     }
 
     public static void setIsVegan(ItemStack stack, boolean isVegan) {
+        if (VeganConfig.useComponents == VeganConfig.DataComponentUsageMode.NONE) {
+            return;
+        }
+
         var isFood = stack.is(VeganTags.SHOULD_HAVE_DATA_COMPONENTS_ADDED) ||
             stack.getUseAnimation() == UseAnim.EAT || stack.getUseAnimation() == UseAnim.DRINK;
 

--- a/common/src/main/resources/assets/vegandelight/lang/en_us.json
+++ b/common/src/main/resources/assets/vegandelight/lang/en_us.json
@@ -89,9 +89,6 @@
   "tooltip.vegandelight.replaces": "Can be used as a replacement for %s.",
 
   "vegandelight.midnightconfig.title": "Vegan Delight",
-  "vegandelight.midnightconfig.dataComponentExplanation": "Vegan Delight can use Minecraft's data component system to keep track of which items are vegan and which aren't. You can choose which items are assigned these components. Keep in mind that items that have different components are not stackable, meaning vegan items won't be stackable with non-vegan ones. By default, only food items are affected by this. Note that the data components are required for the labels (see below) to work correctly.",
-  "vegandelight.midnightconfig.useComponents": "Which items should use data components to differentiate vegan/non-vegan items?",
-  "vegandelight.midnightconfig.labelExplanation": "Vegan Delight can show a 'Vegan' or 'Not Vegan' label on items. You can choose which items have these labels. Keep in mind only items that are chosen above to use vegan data components can show these labels.",
-  "vegandelight.midnightconfig.veganLabelMode": "Which items should Display the 'Vegan' label? By default, all items that were crafted using a substitute (e.g. soymilk instead of cows milk) show the label.",
-  "vegandelight.midnightconfig.notVeganLabelMode": "Which items should Display the 'Not Vegan' label? By default, all item stacks that would normally be vegan, but aren't (like iron ingots that were dropped by a golem and therefore aren't vegan) will show the label."
+  "vegandelight.midnightconfig.dataComponentExplanation": "Vegan Delight can use Minecraft's data component system to keep track of which items are vegan and which aren't. You can choose which items are assigned these components. Keep in mind that items that have different components are not stackable, meaning vegan items won't be stackable with non-vegan ones. By default, all items are affected by this. Note that the data components are required for the labels (see below) to work correctly.",
+  "vegandelight.midnightconfig.useComponents": "Which items should use data components to differentiate vegan/non-vegan items?"
 }


### PR DESCRIPTION
I've added a config that disables the labeling feature entirely. My original intention was to plug through the different labeling options you've already written out, but unfortunately I can't think of a working way to implement them. Or at least I can't think of a working way to implement them that works well with other mods and matches philosophically with my opinion of what it means for an item to be "Vegan" or "Not Vegan". I'd be happy top hop in a call and chat about this with you sometime if you're interested.

Anyways, I've tested and confirmed that this feature works as intended in NeoForge and Fabric.